### PR TITLE
Fix bug that coverage isn't uploaded

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -4,16 +4,19 @@ on:
       - main
 jobs:
   analyze:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.13'
-      - run: python -m pip install uv
       - run: uv sync
-      - uses: paambaati/codeclimate-action@v5
-        env:
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      - run: uv run invoke test.coverage --xml
+      - uses: qltysh/qlty-action/coverage@v1
         with:
-          coverageCommand: uv run invoke test.coverage --xml
+          oidc: true
+          files: coverage.xml
+          format: cobertura


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for code analysis to improve security, streamline Python environment setup, and modernize coverage reporting. The most important changes are grouped below:

**Security and Permissions:**
* Added explicit workflow permissions for `contents: read` and `id-token: write` to enhance security and enable OIDC authentication.

**Python Environment Setup:**
* Replaced `actions/setup-python@v5` and manual `pip install uv` steps with `astral-sh/setup-uv@v6` for more efficient and modern Python environment management.

**Coverage Reporting:**
* Switched from `paambaati/codeclimate-action` to `qltysh/qlty-action/coverage@v1` for coverage reporting, utilizing OIDC authentication and the Cobertura format for coverage output.
* Updated the test coverage command to run directly with `uv run invoke test.coverage --xml`, aligning with the new coverage reporting setup.