### PR TITLE
Enhance linting configuration and support for Python 3.14

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -3,7 +3,7 @@ on:
     inputs:
       python-version:
         type: string
-        default: '3.13'
+        default: '3.14'
     secrets:
       pypi_password:
         required: true

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       python-version:
         type: string
-        default: '3.13'
+        default: '3.14'
 jobs:
   check_style:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-qlty.yml
+++ b/.github/workflows/reusable-qlty.yml
@@ -3,7 +3,7 @@ on:
     inputs:
       python-version:
         type: string
-        default: '3.13'
+        default: '3.14'
       add-prefix:
         type: string
         default: ''

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       support-python-versions:
         type: string
-        default: "[ '3.13', '3.12', '3.11', '3.10' ]"
+        default: "[ '3.14', '3.13', '3.12', '3.11', '3.10' ]"
       is-supporting-python-3-7-in-linux:
         type: boolean
         default: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   call-workflow-test:
     uses: ./.github/workflows/reusable-test.yml
     with:
-      support-python-versions: "[ '3.13', '3.12', '3.11', '3.10', '3.9', '3.8' ]"
+      support-python-versions: "[ '3.14', '3.13', '3.12', '3.11', '3.10', '3.9', '3.8' ]"
       is-supporting-python-3-7-in-linux: true
   call-workflow-lint:
     uses: ./.github/workflows/reusable-lint.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,9 @@
-FROM futureys/claude-code-python-development:20260124195000
+FROM futureys/claude-code-python-development:20260407212500
 COPY pyproject.toml /workspace/
 # - Using uv in Docker | uv
 #   https://docs.astral.sh/uv/guides/integration/docker/#caching
 RUN --mount=type=cache,target=/root/.cache/uv \
-# Reason: The dependency of docformatter: untokenize does not support Python 3.14 yet.
-# - Installation failing with Python 3.14 · Issue #4 · myint/untokenize
-#   https://github.com/myint/untokenize/issues/4
-# And the uv can't lock even if we limit the Python version for docformatter in pyproject.toml:
-# # uv sync
-#   × Failed to build `untokenize==0.1.1`
-#   ├─▶ The build backend returned an error
-#   ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
-# 
-#       [stderr]
-#       Traceback (most recent call last):
-#         File "<string>", line 14, in <module>
-#           requires = get_requires_for_build({})
-#         File "/root/.cache/uv/builds-v0/.tmpLGGZWk/lib/python3.14/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
-#           return self._get_build_requires(config_settings, requirements=[])
-#                  ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#         File "/root/.cache/uv/builds-v0/.tmpLGGZWk/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
-#           self.run_setup()
-#           ~~~~~~~~~~~~~~^^
-#         File "/root/.cache/uv/builds-v0/.tmpLGGZWk/lib/python3.14/site-packages/setuptools/build_meta.py", line 512, in run_setup
-#           super().run_setup(setup_script=setup_script)
-#           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#         File "/root/.cache/uv/builds-v0/.tmpLGGZWk/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
-#           exec(code, locals())
-#           ~~~~^^^^^^^^^^^^^^^^
-#         File "<string>", line 19, in <module>
-#           json.dump(requires, fp)
-#                              ^^^^
-#         File "<string>", line 14, in version
-#       AttributeError: 'Constant' object has no attribute 's'
-# 
-#       hint: This usually indicates a problem with the package or the build environment.
-#   help: `untokenize` (v0.1.1) was included because `invokelint:dev` (v0.14.0) depends on `docformatter` (v1.7.7) which depends on `untokenize>=0.1.1, <0.2.0`
-    uv sync --python 3.13
+    uv sync
 COPY . /workspace
 ENTRYPOINT [ "uv", "run" ]
 CMD ["invoke", "test.coverage"]

--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ Optionally, you can use [autoflake], [isort], and [Black] instead of [Ruff] form
 
 Runs following fast linters at once:
 
-1. [Xenon]
+1. [Xenon] (Optional)
 2. [Ruff]
 3. [Bandit]
 4. [dodgy]
 5. [Flake8]
 6. [pydocstyle] (Optional)
 
-The format task ([described later](#inv-style)) also run before running above linters. You can skip them by `--skip-format` option.
+The format task ([described later](#inv-style)) also run before running above linters. You can skip them by `--skip-format` option. Use `--no-xenon` to skip Xenon, and `--pydocstyle` to enable pydocstyle.
 
 ### `inv lint.deep`
 
@@ -192,7 +192,8 @@ dev = [
     "pydocstyle; python_version >= '3.6'",
     "pylint",
     "pytest",
-    # Since the radon can't run when use pytest log format:
+    # If you want to use Radon for code complexity and maintainability index checking
+    # Note that the version should be less than 6.0.0 because of the issue of Radon with pytest log format.
     # - Radon can't run when use pytest log fornat: `$()d` · Issue #251 · rubik/radon
     #   https://github.com/rubik/radon/issues/251
     "radon<6.0.0",
@@ -200,6 +201,7 @@ dev = [
     "semgrep;python_version>='3.9' or python_version>='3.6' and platform_system=='Linux'",
     # To resolve type checking for `from invoke import Collection` in tasks.py
     "types-invoke",
+    # If you want to use not Ruff but Xenon for complexity checking
     "xenon",
 ]
 ```

--- a/invokelint/lint.py
+++ b/invokelint/lint.py
@@ -132,6 +132,7 @@ def call_pydocstyle(context: Context, **kwargs: Any) -> list[Result]:  # noqa: A
         "ruff": "Leaves Ruff warnings not fixed (not apply `ruff check --fix`, only `ruff format` is applied)",
         "by_ruff": "Formats code by Ruff",
         "no_ruff": "Formats code by autoflake, isort, and Black (requires to install them)",
+        "no_xenon": "Skips Xenon linting.",
         "pydocstyle": "Runs pydocstyle",
     },
 )
@@ -143,15 +144,18 @@ def fast(  # noqa: PLR0913
     ruff: bool = False,
     by_ruff: bool = False,
     no_ruff: bool = False,
+    no_xenon: bool = False,
     # Reason: To name command line option.
     pydocstyle: bool = False,  # pylint: disable=redefined-outer-name
 ) -> list[Result]:
-    """Runs fast linting (xenon, ruff, bandit, dodgy, flake8, pydocstyle).
+    """Runs fast linting (ruff, bandit, dodgy, flake8, xenon, pydocstyle).
 
     Xenon is prioritized since it effects fundamental coding structure.
     """
     list_result = [] if skip_format else fmt(context, ruff=ruff, by_ruff=by_ruff, no_ruff=no_ruff)
-    tasks = [call_xenon, call_ruff, call_bandit, call_dodgy, call_flake8]
+    tasks: list[TaskFunction] = [call_ruff, call_bandit, call_dodgy, call_flake8]
+    if not no_xenon:
+        tasks.insert(0, call_xenon)
     if pydocstyle:
         tasks.append(call_pydocstyle)
     list_result.extend(run_in_order(tasks, context))

--- a/invokelint/style.py
+++ b/invokelint/style.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from typing import Any
 
 from invoke import Collection
@@ -27,6 +28,8 @@ def docformatter(context: Context, *, check: bool = False, **kwargs: Any) -> lis
     - Add pyproject.toml support for config (Issue #10) by weibullguy · Pull Request #77 · PyCQA/docformatter
     https://github.com/PyCQA/docformatter/pull/77
     """
+    if not shutil.which("docformatter"):
+        return []
     docformatter_options = f" --recursive {'--check' if check else '--in-place'}"
     return [run_in_pty(context, f"docformatter{docformatter_options} {' '.join(PYTHON_DIRS)}", warn=True)]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,6 +314,11 @@ fixable = [
 # To follow H301: Do not import more than one module per line (*) in Flake8 + openstack/hacking
 force-single-line = true
 
+[tool.ruff.lint.mccabe]
+# The default value: 10 is too loose,
+# 5 is as same as the default value of Radon for A rank that we use without any problems for a decade.
+max-complexity = 5
+
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Software Development",
     "Topic :: Software Development :: Build Tools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,11 @@ add_ignore = [
     "D415",  # First line should end with a period, question mark, or exclamation point
 ]
 
+[tool.pylint]
+disable = [
+    # We check line length by flake8-bugbear B950.
+    "line-too-long",
+]
 
 [tool.pylint.basic]
 docstring-min-length = "7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,14 @@ dev = [
     #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
     "dlint>=0.14.0",
     # To the docformatter load pyproject.toml settings:
-    "docformatter[tomli]; python_version < '3.11' and python_version >= '3.6'",
-    "docformatter; python_version >= '3.11'",
+    # docformatter < 1.7.8 depends on untokenize==0.1.1, whose setup.py uses ast.Constant.s removed in Python 3.14:
+    # - Installation fails on Python 3.14 · Issue #327 · PyCQA/docformatter
+    #   https://github.com/PyCQA/docformatter/issues/327
+    # uv builds packages using the current interpreter to collect metadata for the lock file, so even a marker
+    # like `python_version < '3.14'` cannot prevent the build from running on Python 3.14 and failing.
+    # docformatter >= 1.7.8 dropped untokenize but requires Python >= 3.10, so Python 3.7-3.9 are excluded.
+    "docformatter[tomli]>=1.7.8; python_version >= '3.10' and python_version < '3.11'",
+    "docformatter>=1.7.8; python_version >= '3.11'",
     "dodgy",
     # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
     # We should avoid the versions that is not compatible with the hacking,

--- a/tests/path/test___init__.py
+++ b/tests/path/test___init__.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 def test(context: "Context", capsys: "pytest.CaptureFixture[str]") -> None:
     """Function: debug() should print packages and root packages."""
+    # Reason: Black <=23.x (Python 3.9-) splits closing `"""` onto its own line, triggering ruff COM812.
+    # fmt: off
     expected = dedent("""\
         Setuptools detected packages: ['invokelint', 'invokelint.path']
         Root packages: ['invokelint']
@@ -20,6 +22,7 @@ def test(context: "Context", capsys: "pytest.CaptureFixture[str]") -> None:
         Python file or directories to lint: ['invokelint', 'setup.py', 'tasks.py', 'tests']
         Python file or directories to lint excluding test packages: ['invokelint', 'setup.py', 'tasks.py']
     """)
+    # fmt: on
     debug(context)
     captured = capsys.readouterr()
     assert captured.out == expected

--- a/tests/path/test___init__.py
+++ b/tests/path/test___init__.py
@@ -12,16 +12,14 @@ if TYPE_CHECKING:
 
 def test(context: "Context", capsys: "pytest.CaptureFixture[str]") -> None:
     """Function: debug() should print packages and root packages."""
-    expected = dedent(
-        """\
-            Setuptools detected packages: ['invokelint', 'invokelint.path']
-            Root packages: ['invokelint']
-            Setuptools detected Python modules: ['setup', 'tasks']
-            Existing test packages: ['tests']
-            Python file or directories to lint: ['invokelint', 'setup.py', 'tasks.py', 'tests']
-            Python file or directories to lint excluding test packages: ['invokelint', 'setup.py', 'tasks.py']
-        """,
-    )
+    expected = dedent("""\
+        Setuptools detected packages: ['invokelint', 'invokelint.path']
+        Root packages: ['invokelint']
+        Setuptools detected Python modules: ['setup', 'tasks']
+        Existing test packages: ['tests']
+        Python file or directories to lint: ['invokelint', 'setup.py', 'tasks.py', 'tests']
+        Python file or directories to lint excluding test packages: ['invokelint', 'setup.py', 'tasks.py']
+    """)
     debug(context)
     captured = capsys.readouterr()
     assert captured.out == expected

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -97,13 +97,13 @@ def test_xenon(context: "Context") -> None:
     check_list_result(xenon(context), [COMMAND_EXPECTED_XENON])
 
 
-LIST_COMMAND_EXPECTED = [
-    COMMAND_EXPECTED_XENON,
+LIST_COMMAND_EXPECTED_WITHOUT_XENON = [
     COMMAND_EXPECTED_RUFF_CHECK,
     COMMAND_EXPECTED_BANDIT,
     COMMAND_EXPECTED_DODGY,
     COMMAND_EXPECTED_FLAKE8,
 ]
+LIST_COMMAND_EXPECTED = [COMMAND_EXPECTED_XENON, *LIST_COMMAND_EXPECTED_WITHOUT_XENON]
 
 
 def test_fast(context: "Context") -> None:
@@ -119,6 +119,12 @@ def test_fast_pydocstyle(context: "Context") -> None:
         list_result,
         LIST_COMMAND_EXPECTED_STYLE_BY_RUFF + LIST_COMMAND_EXPECTED + [COMMAND_EXPECTED_PYDOCSTYLE],
     )
+
+
+def test_fast_no_xenon(context: "Context") -> None:
+    """Command should success and run appropriate commands."""
+    list_result = fast(context, no_xenon=True)
+    check_list_result(list_result, LIST_COMMAND_EXPECTED_STYLE_BY_RUFF + LIST_COMMAND_EXPECTED_WITHOUT_XENON)
 
 
 def test_fast_ruff(context: "Context") -> None:

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,5 +1,6 @@
 """Tests for `style` package."""
 
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,9 +14,9 @@ if TYPE_CHECKING:
 
 PYTHON_DIR = "invokelint setup.py tasks.py tests"
 
-LIST_COMMAND_EXPECTED_STYLE_COMMON = [
-    f"docformatter --recursive --in-place {PYTHON_DIR}",
-]
+LIST_COMMAND_EXPECTED_STYLE_COMMON = (
+    [f"docformatter --recursive --in-place {PYTHON_DIR}"] if sys.version_info >= (3, 10) else []
+)
 LIST_COMMAND_EXPECTED_STYLE_WITHOUT_RUFF = [
     *LIST_COMMAND_EXPECTED_STYLE_COMMON,
     f"autoflake --recursive --in-place {PYTHON_DIR}",
@@ -37,9 +38,9 @@ LIST_COMMAND_EXPECTED_STYLE_NO_RUFF = [
     f"ruff check --show-fixes {PYTHON_DIR}",
     f"ruff check --fix --show-fixes {PYTHON_DIR}",
 ]
-LIST_COMMAND_EXPECTED_STYLE_CHECK_COMMON = [
-    f"docformatter --recursive --check {PYTHON_DIR}",
-]
+LIST_COMMAND_EXPECTED_STYLE_CHECK_COMMON = (
+    [f"docformatter --recursive --check {PYTHON_DIR}"] if sys.version_info >= (3, 10) else []
+)
 LIST_COMMAND_EXPECTED_STYLE_CHECK_NO_RUFF = [
     *LIST_COMMAND_EXPECTED_STYLE_CHECK_COMMON,
     f"autoflake --recursive --check {PYTHON_DIR}",

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -19,20 +19,18 @@ from tests.testlibraries import check_result
 if TYPE_CHECKING:
     from pytest_mock import MockFixture
 
-EXPECTED_STDOUT = dedent(
-    """\
-        ================== test session starts ====================
-        platform linux -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
-        rootdir: /workspace
-        collected 17 items
+EXPECTED_STDOUT = dedent("""
+    ================== test session starts ====================
+    platform linux -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
+    rootdir: /workspace
+    collected 17 items
 
-        tests/test_lint.py ............                      [ 70%]
-        tests/test_run.py .                                  [ 76%]
-        tests/test_style.py ..                               [ 88%]
-        tests/test_test.py ....                              [100%]
-        ================== 17 passed in 12.61s ====================
-    """,
-)
+    tests/test_lint.py ............                      [ 70%]
+    tests/test_run.py .                                  [ 76%]
+    tests/test_style.py ..                               [ 88%]
+    tests/test_test.py ....                              [100%]
+    ================== 17 passed in 12.61s ====================
+""")
 
 
 def test_fast() -> None:
@@ -60,20 +58,18 @@ def test_run_test_all() -> None:
     context.run.assert_called_with(expected_command, pty=expected_pty)  # type: ignore[attr-defined]
 
 
-EXPECTED_STDOUT_REPORT = dedent(
-    """\
-        Name                     Stmts   Miss  Cover   Missing
-        ------------------------------------------------------
-        invokelint/__init__.py       3      0   100%
-        invokelint/lint.py          56      0   100%
-        invokelint/path.py          11      0   100%
-        invokelint/run.py           18      0   100%
-        invokelint/style.py         33      0   100%
-        invokelint/test.py          28      0   100%
-        ------------------------------------------------------
-        TOTAL                      149     11   100%
-    """,
-)
+EXPECTED_STDOUT_REPORT = dedent("""
+    Name                     Stmts   Miss  Cover   Missing
+    ------------------------------------------------------
+    invokelint/__init__.py       3      0   100%
+    invokelint/lint.py          56      0   100%
+    invokelint/path.py          11      0   100%
+    invokelint/run.py           18      0   100%
+    invokelint/style.py         33      0   100%
+    invokelint/test.py          28      0   100%
+    ------------------------------------------------------
+    TOTAL                      149     11   100%
+""")
 EXPECTED_COMMAND_RUN = "coverage run --source invokelint -m pytest"
 EXPECTED_COMMAND_COMBINE = "coverage combine"
 EXPECTED_COMMAND_REPORT = "coverage report --show-missing"
@@ -199,13 +195,11 @@ def test_coverage_combine_with_multiprocessing_files(mocker: "MockFixture") -> N
     # Mock Path(".").glob to return multiple coverage files (simulating multiprocessing)
     mock_glob = mocker.patch("pathlib.Path.glob")
     mock_glob.return_value = iter([Path(".coverage.12345"), Path(".coverage.67890"), Path(".coverage.11111")])
-    expected_combine_output = dedent(
-        """\
-            Combined data file .coverage.12345
-            Combined data file .coverage.67890
-            Combined data file .coverage.11111
-        """,
-    )
+    expected_combine_output = dedent("""\
+        Combined data file .coverage.12345
+        Combined data file .coverage.67890
+        Combined data file .coverage.11111
+    """)
     expected_pty = platform.system() == "Linux"
     context = MockContext(
         run={

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -19,6 +19,8 @@ from tests.testlibraries import check_result
 if TYPE_CHECKING:
     from pytest_mock import MockFixture
 
+# Reason: Black <=23.x (Python 3.9-) splits closing `"""` onto its own line, triggering ruff COM812.
+# fmt: off
 EXPECTED_STDOUT = dedent("""
     ================== test session starts ====================
     platform linux -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
@@ -31,6 +33,7 @@ EXPECTED_STDOUT = dedent("""
     tests/test_test.py ....                              [100%]
     ================== 17 passed in 12.61s ====================
 """)
+# fmt: on
 
 
 def test_fast() -> None:
@@ -58,6 +61,8 @@ def test_run_test_all() -> None:
     context.run.assert_called_with(expected_command, pty=expected_pty)  # type: ignore[attr-defined]
 
 
+# Reason: Black <=23.x (Python 3.9-) splits closing `"""` onto its own line, triggering ruff COM812.
+# fmt: off
 EXPECTED_STDOUT_REPORT = dedent("""
     Name                     Stmts   Miss  Cover   Missing
     ------------------------------------------------------
@@ -70,6 +75,7 @@ EXPECTED_STDOUT_REPORT = dedent("""
     ------------------------------------------------------
     TOTAL                      149     11   100%
 """)
+# fmt: on
 EXPECTED_COMMAND_RUN = "coverage run --source invokelint -m pytest"
 EXPECTED_COMMAND_COMBINE = "coverage combine"
 EXPECTED_COMMAND_REPORT = "coverage report --show-missing"
@@ -195,11 +201,14 @@ def test_coverage_combine_with_multiprocessing_files(mocker: "MockFixture") -> N
     # Mock Path(".").glob to return multiple coverage files (simulating multiprocessing)
     mock_glob = mocker.patch("pathlib.Path.glob")
     mock_glob.return_value = iter([Path(".coverage.12345"), Path(".coverage.67890"), Path(".coverage.11111")])
+    # Reason: Black <=23.x (Python 3.9-) splits closing `"""` onto its own line, triggering ruff COM812.
+    # fmt: off
     expected_combine_output = dedent("""\
         Combined data file .coverage.12345
         Combined data file .coverage.67890
         Combined data file .coverage.11111
     """)
+    # fmt: on
     expected_pty = platform.system() == "Linux"
     context = MockContext(
         run={


### PR DESCRIPTION
This pull request updates the project to support Python 3.14 across the development environment, CI workflows, and documentation. It also improves the flexibility of the linting process by making Xenon an optional linter, adds configuration for code complexity checks, and includes minor test and documentation cleanups.

**Python 3.14 Support and Environment Updates:**

- Updated all GitHub Actions workflow files (`reusable-deploy.yml`, `reusable-lint.yml`, `reusable-qlty.yml`, `reusable-test.yml`, `test.yml`) to use Python 3.14 as the default or add it to the supported versions. [[1]](diffhunk://#diff-24a4d3afa8e6738124758166b9bdbe84be663cff194dc7058f010d84d79bb53dL6-R6) [[2]](diffhunk://#diff-b6d44e71fe317ece2f859934a2c10932ffc2ef6e7b8523f98aea70257b7974adL7-R7) [[3]](diffhunk://#diff-2a4affac80e39e138c0c939966326f427dfaa0ec480f98cf36faf2e1c2764edbL6-R6) [[4]](diffhunk://#diff-e386584fe70c301924ab6a8d4656b54ef92ed1961e6eb6f77c155be3475615f6L7-R7) [[5]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L13-R13)
- Updated the `Dockerfile` to use a new base image compatible with Python 3.14 and removed the workaround for the `untokenize`/`docformatter` issue, as it is no longer needed.
- Added Python 3.14 to the `classifiers` in `pyproject.toml` to declare official support.

**Linting and Code Quality Improvements:**

- Made Xenon an optional linter in the fast linting task:
  - Added a `no_xenon` option to the `fast` linting command, updated the help text, and adjusted the order of linter execution. [[1]](diffhunk://#diff-cd9215b58469f6b56da234627188db281dbf14be10fabb939c7fb81efc2b26eaR135) [[2]](diffhunk://#diff-cd9215b58469f6b56da234627188db281dbf14be10fabb939c7fb81efc2b26eaR147-R158)
  - Updated documentation and test cases to reflect Xenon's optional status and new command-line options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R104) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L195-R204) [[3]](diffhunk://#diff-11b4c502df02b23a6f1ff6164b6f6145f03cb413b2beef3dd6a5c1c11653bc23L100-R106) [[4]](diffhunk://#diff-11b4c502df02b23a6f1ff6164b6f6145f03cb413b2beef3dd6a5c1c11653bc23R124-R129)
- Added a configuration section for Pylint in `pyproject.toml` to disable line length warnings (handled by Flake8) and set a minimum docstring length.
- Configured Ruff's McCabe complexity checker to use a stricter `max-complexity` of 5, aligning with Radon's default for "A" rank.

**Test and Documentation Cleanups:**

- Simplified multi-line string definitions in test files to improve readability and consistency. [[1]](diffhunk://#diff-a8cfdfa2a20f4c01ca1f46e0a5cdee59e6a1b7d0d62bf3d5ea0d7ff8225e4dbeL15-R22) [[2]](diffhunk://#diff-5a3cc3352be9423f5244d82f1ea97434ab5e7621366e2a589b0165b661c082aeL22-R22) [[3]](diffhunk://#diff-5a3cc3352be9423f5244d82f1ea97434ab5e7621366e2a589b0165b661c082aeL34-R33) [[4]](diffhunk://#diff-5a3cc3352be9423f5244d82f1ea97434ab5e7621366e2a589b0165b661c082aeL63-R61) [[5]](diffhunk://#diff-5a3cc3352be9423f5244d82f1ea97434ab5e7621366e2a589b0165b661c082aeL75-R72) [[6]](diffhunk://#diff-5a3cc3352be9423f5244d82f1ea97434ab5e7621366e2a589b0165b661c082aeL202-R202)

These changes collectively modernize the project's Python support, make linting more flexible, and improve maintainability.