### PR TITLE
Add option to disable Xenon feature

### DIFF
--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -5,6 +5,9 @@ on:
       python-version:
         type: string
         default: '3.14'
+      enable-xenon:
+        type: boolean
+        default: true
 jobs:
   check_style:
     runs-on: ubuntu-latest
@@ -23,7 +26,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - run: uv sync
-      - run: uv run invoke lint
+      - run: uv run invoke lint ${{ inputs.enable-xenon == false && '--no-xenon' || '' }}
   check_lint_deep:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request updates the `.github/workflows/reusable-lint.yml` workflow to make the use of Xenon (a code complexity checker) configurable via an input parameter. By default, Xenon is enabled, but it can now be disabled when running the lint job.

**Workflow configuration improvements:**

* Added a new boolean input parameter `enable-xenon` to the workflow, defaulting to `true`, allowing users to control whether Xenon runs during linting.
* Modified the `lint` command in the `check_style` job to conditionally include the `--no-xenon` flag when `enable-xenon` is set to `false`.