### PR TITLE
Replace reusable workflows with the one in the independent repositories

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,14 +20,21 @@ on:
   schedule:
     - cron: '15 16 * * 6'
 
+permissions:
+  # required for all workflows
+  security-events: write
+  # required to fetch internal or private CodeQL packs
+  packages: read
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
+
 jobs:
   call-workflow:
+    uses: yukihiko-shinoda/reusable-workflow-codeql-python/.github/workflows/workflow.yml@ca5a2fbce666756cb15aca6e3a33852588728909  # v1.0.0
     permissions:
-      # required for all workflows
       security-events: write
-      # required to fetch internal or private CodeQL packs
       packages: read
-      # only required for workflows in private repositories
       actions: read
       contents: read
-    uses: ./.github/workflows/reusable-codeql-analysis.yml
+    

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,10 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+permissions:
+  contents: read
 jobs:
   call-workflow:
-    uses: ./.github/workflows/reusable-deploy.yml
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-deploy/.github/workflows/workflow.yml@eab497a87ebe0cc07a02f723660b750be925f4aa  # v1.0.0
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -2,9 +2,15 @@ on:
   push:
     branches:
       - main
+# For OIDC token exchange with Qlty:
+# - Configuring OpenID Connect in cloud providers - GitHub Docs
+#   https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers#adding-permissions-settings
+permissions:
+  contents: read
+  id-token: write
 jobs:
   analyze:
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-qlty/.github/workflows/workflow.yml@732676e4d8cea832b97f2f66ee73fd65fa837e7d
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/reusable-qlty.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,15 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   call-workflow-test:
-    uses: ./.github/workflows/reusable-test.yml
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-test/.github/workflows/workflow.yml@3deca6708b4c2b623c7eac175a63973c05c64e3b
     with:
       support-python-versions: "[ '3.14', '3.13', '3.12', '3.11', '3.10', '3.9', '3.8' ]"
       is-supporting-python-3-7-in-linux: true
   call-workflow-lint:
-    uses: ./.github/workflows/reusable-lint.yml
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-lint/.github/workflows/workflow.yml@0966c64de69c044585bbdca96980a8393c761829
+    with:
+      enable-xenon: true

--- a/invokelint/lint.py
+++ b/invokelint/lint.py
@@ -112,8 +112,15 @@ def flake8(context: Context, *, radon_show_closures: bool = True) -> list[Result
 
 
 # Reason: Compatibility with semgrep task to be called from fast().. pylint: disable=unused-argument
-def call_flake8(context: Context, *, no_xenon: bool = False, **kwargs: Any) -> list[Result]:  # noqa: ARG001
-    return flake8(context, radon_show_closures=not no_xenon)
+def call_flake8(  # pylint: disable=redefined-outer-name
+    context: Context,
+    *,
+    xenon: bool = False,
+    no_xenon: bool = False,
+    **kwargs: Any,  # noqa: ARG001
+) -> list[Result]:
+    """Calls flake8 with radon_show_closures enabled only when xenon is active."""
+    return flake8(context, radon_show_closures=xenon and not no_xenon)
 
 
 @task
@@ -133,6 +140,7 @@ def call_pydocstyle(context: Context, **kwargs: Any) -> list[Result]:  # noqa: A
         "ruff": "Leaves Ruff warnings not fixed (not apply `ruff check --fix`, only `ruff format` is applied)",
         "by_ruff": "Formats code by Ruff",
         "no_ruff": "Formats code by autoflake, isort, and Black (requires to install them)",
+        "xenon": "Runs xenon",
         "no_xenon": "Skips Xenon linting.",
         "pydocstyle": "Runs pydocstyle",
     },
@@ -145,21 +153,23 @@ def fast(  # noqa: PLR0913
     ruff: bool = False,
     by_ruff: bool = False,
     no_ruff: bool = False,
+    # Reason: To name command line option.
+    xenon: bool = False,  # pylint: disable=redefined-outer-name
     no_xenon: bool = False,
     # Reason: To name command line option.
     pydocstyle: bool = False,  # pylint: disable=redefined-outer-name
 ) -> list[Result]:
-    """Runs fast linting (ruff, bandit, dodgy, flake8, xenon, pydocstyle).
+    """Runs fast linting (ruff, bandit, dodgy, flake8, pydocstyle).
 
-    Xenon is prioritized since it effects fundamental coding structure.
+    Xenon runs when --xenon is given.
     """
     list_result = [] if skip_format else fmt(context, ruff=ruff, by_ruff=by_ruff, no_ruff=no_ruff)
     tasks: list[TaskFunction] = [call_ruff, call_bandit, call_dodgy, call_flake8]
-    if not no_xenon:
+    if xenon and not no_xenon:
         tasks.insert(0, call_xenon)
     if pydocstyle:
         tasks.append(call_pydocstyle)
-    list_result.extend(run_in_order(tasks, context, no_xenon=no_xenon))
+    list_result.extend(run_in_order(tasks, context, xenon=xenon, no_xenon=no_xenon))
     return list_result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,15 @@ dev = [
     # ModuleNotFoundError: No module named 'pkg_resources'
     # - [BUG] Restore \`pkg\_resources\` · Issue #5174 · pypa/setuptools
     #   https://github.com/pypa/setuptools/issues/5174
-    "setuptools<82.0.0;python_version=='3.9'",
-    "semgrep;python_version>='3.9' or python_version>='3.6' and platform_system=='Linux'",
+    "setuptools<82.0.0; python_version == '3.9'",
+    # If we simply lock as "semgrep; python_version >= '3.9' or python_version>='3.6' and platform_system=='Linux'",
+    # the semgrep 1.121.0 is installed in Python 3.14 and cause following error:
+    #     File "/root/.local/share/uv/python/cpython-3.14.5-linux-aarch64-gnu/lib/python3.14/importlib/__init__.py", line 88, in import_module
+    #       return _bootstrap._gcd_import(name[level:], package, level)
+    #              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    #   TypeError: Metaclasses with custom tp_new are not supported.
+    "semgrep; python_version >= '3.9' and python_version < '3.10' or python_version>='3.6' and platform_system=='Linux'",
+    "semgrep>=1.122.0;python_version >= '3.10'",
     "types-invoke",
     "types-setuptools",
     # To test invoke dist without package: `build`

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -98,19 +98,20 @@ def test_xenon(context: "Context") -> None:
     check_list_result(xenon(context), [COMMAND_EXPECTED_XENON])
 
 
-LIST_COMMAND_EXPECTED_WITHOUT_XENON = [
+LIST_COMMAND_EXPECTED = [
     COMMAND_EXPECTED_RUFF_CHECK,
     COMMAND_EXPECTED_BANDIT,
     COMMAND_EXPECTED_DODGY,
     COMMAND_EXPECTED_FLAKE8_NO_RADON,
 ]
-LIST_COMMAND_EXPECTED = [
+LIST_COMMAND_EXPECTED_WITH_XENON = [
     COMMAND_EXPECTED_XENON,
     COMMAND_EXPECTED_RUFF_CHECK,
     COMMAND_EXPECTED_BANDIT,
     COMMAND_EXPECTED_DODGY,
     COMMAND_EXPECTED_FLAKE8,
 ]
+LIST_COMMAND_EXPECTED_WITHOUT_XENON = LIST_COMMAND_EXPECTED
 
 
 def test_fast(context: "Context") -> None:
@@ -128,9 +129,15 @@ def test_fast_pydocstyle(context: "Context") -> None:
     )
 
 
+def test_fast_xenon(context: "Context") -> None:
+    """Command should success and run appropriate commands."""
+    list_result = fast(context, xenon=True)
+    check_list_result(list_result, LIST_COMMAND_EXPECTED_STYLE_BY_RUFF + LIST_COMMAND_EXPECTED_WITH_XENON)
+
+
 def test_fast_no_xenon(context: "Context") -> None:
     """Command should success and run appropriate commands."""
-    list_result = fast(context, no_xenon=True)
+    list_result = fast(context, xenon=True, no_xenon=True)
     check_list_result(list_result, LIST_COMMAND_EXPECTED_STYLE_BY_RUFF + LIST_COMMAND_EXPECTED_WITHOUT_XENON)
 
 


### PR DESCRIPTION
This pull request updates all GitHub Actions workflow files to use external reusable workflows from the `yukihiko-shinoda` organization instead of local workflow files. It also standardizes and enhances workflow permissions for improved security and compatibility, including adding permissions blocks where needed.

**Workflow migration to external reusable workflows:**

* Updated the `test`, `lint`, `deploy`, `qlty`, and `codeql` workflows to use external reusable workflows from the `yukihiko-shinoda` organization, replacing references to local reusable workflow files [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R9-R20) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R5-R9) [[3]](diffhunk://#diff-5b16d201a687c908f0427a1d319b9d2002e28137c74d84454bf006c1ef2ddecbR5-L10) [[4]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L33-R40).

**Permissions and security improvements:**

* Added or updated `permissions` blocks in all workflow files to explicitly specify required permissions, such as `contents: read`, `id-token: write`, and others, for better security and compatibility with OIDC and other integrations [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R9-R20) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R5-R9) [[3]](diffhunk://#diff-5b16d201a687c908f0427a1d319b9d2002e28137c74d84454bf006c1ef2ddecbR5-L10) [[4]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L23-L24).

**Other improvements:**

* Added comments in `qlty.yml` to clarify the need for OIDC token exchange and provide documentation references.
* Enabled the `xenon` linter in the lint workflow by setting `enable-xenon: true`.