### PR TITLE
Add lowest version constraint for semgrep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = [
-    "invokelint[lint,lint-deep,style,style-legacy,test,dist,xenon]",
-    "bump-my-version",
-    "pytest-mock",
-    "pyvelocity; python_version >= '3.9'",
-    # To test invoke dist without package: `build`
-    "wheel",
-    "types-setuptools",
+  "invokelint[lint,lint-deep,style,style-legacy,test,dist,xenon]",
+  "bump-my-version",
+  "pytest-mock",
+  "pyvelocity; python_version >= '3.9'",
+  # To test invoke dist without package: `build`
+  "wheel",
+  "types-setuptools",
 ]
 
 [project]
@@ -22,159 +22,182 @@ readme = "README.md"
 requires-python = ">=3.7"
 license = {file = "LICENSE"}
 keywords = [
-    "autoflake",
-    "bandit",
-    "black",
-    "build",
-    "coverage",
-    "dist",
-    "docformatter",
-    "doggy",
-    "flake8",
-    "invokelint",
-    "isort",
-    "mypy",
-    "pydocstyle",
-    "pylint",
-    "pytest",
-    "radon",
-    "ruff",
-    "semgrep",
-    "xenon",
+  "autoflake",
+  "bandit",
+  "black",
+  "build",
+  "coverage",
+  "dist",
+  "docformatter",
+  "doggy",
+  "flake8",
+  "invokelint",
+  "isort",
+  "mypy",
+  "pydocstyle",
+  "pylint",
+  "pytest",
+  "radon",
+  "ruff",
+  "semgrep",
+  "xenon",
 ]
 authors = [
-    {name = "Yukihiko Shinoda", email = "yuk.hik.future@gmail.com"},
+  {name = "Yukihiko Shinoda", email = "yuk.hik.future@gmail.com"},
 ]
 maintainers = [
-    {name = "Yukihiko Shinoda", email = "yuk.hik.future@gmail.com"},
+  {name = "Yukihiko Shinoda", email = "yuk.hik.future@gmail.com"},
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Natural Language :: English",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "Topic :: Security",
-    "Topic :: Software Development",
-    "Topic :: Software Development :: Build Tools",
-    "Topic :: Software Development :: Documentation",
-    "Topic :: Software Development :: Libraries",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Software Development :: Quality Assurance",
-    "Topic :: Software Development :: Testing",
-    "Topic :: Software Development :: Testing :: Unit",
-    "Typing :: Typed",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Natural Language :: English",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Security",
+  "Topic :: Software Development",
+  "Topic :: Software Development :: Build Tools",
+  "Topic :: Software Development :: Documentation",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Software Development :: Quality Assurance",
+  "Topic :: Software Development :: Testing",
+  "Topic :: Software Development :: Testing :: Unit",
+  "Typing :: Typed",
 ]
 dependencies = [
-    # To support unicode to the Windows console by echo().
-    # - Utilities — Click Documentation (8.2.x)
-    #   https://click.palletsprojects.com/en/latest/utils/
-    "click",
-    "invoke",
-    "packagediscovery>=0.2.0",
-    "types-invoke",
+  # To support unicode to the Windows console by echo().
+  # - Utilities — Click Documentation (8.2.x)
+  #   https://click.palletsprojects.com/en/latest/utils/
+  "click",
+  "invoke",
+  "packagediscovery>=0.2.0",
+  "types-invoke",
 ]
 
 [project.optional-dependencies]
 basic = [
-    "invokelint[lint,lint-deep,style,test,dist]",
+  "invokelint[lint,lint-deep,style,test,dist]",
 ]
 dist = [
-    "build",
+  "build",
 ]
 lint = [
-    "bandit; python_version >= '3.7'",
-    "cohesion",
-    # The dlint less than 0.14.0 limits max version of flake8.
-    # - dlint/requirements.txt at 0.13.0 · dlint-py/dlint
-    #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
-    "dlint>=0.14.0",
-    "dodgy",
-    # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
-    # We should avoid the versions that is not compatible with the hacking,
-    # considering the speed of dependency calculation process
-    "flake8!=6.0.0,!=5.0.0,>=4.0.1; python_version >= '3.6'",
-    # To replace E501 in pycodestyle with B950 in flake8-bugbear:
-    # - Using Black with other tools - Black 25.1.0 documentation
-    #   https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#bugbear
-    "flake8-bugbear",
-    # To use pyproject.toml for Flake8 configuration
-    "Flake8-pyproject",
-    # Latest hacking depends on legacy version of flake8, and legacy hacking doesn't narrow flake8 version.
-    # When unpin hacking, it has possibility to install too legacy version of hacking.
-    "hacking>=5.0.0; python_version >= '3.8'",
-    "ruff; python_version >= '3.7'",
+  "bandit; python_version >= '3.7'",
+  "cohesion",
+  # The dlint less than 0.14.0 limits max version of flake8.
+  # - dlint/requirements.txt at 0.13.0 · dlint-py/dlint
+  #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
+  "dlint>=0.14.0",
+  "dodgy",
+  # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
+  # We should avoid the versions that is not compatible with the hacking,
+  # considering the speed of dependency calculation process
+  "flake8!=6.0.0,!=5.0.0,>=4.0.1; python_version >= '3.6'",
+  # To replace E501 in pycodestyle with B950 in flake8-bugbear:
+  # - Using Black with other tools - Black 25.1.0 documentation
+  #   https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#bugbear
+  "flake8-bugbear",
+  # To use pyproject.toml for Flake8 configuration
+  "Flake8-pyproject",
+  # Latest hacking depends on legacy version of flake8, and legacy hacking doesn't narrow flake8 version.
+  # When unpin hacking, it has possibility to install too legacy version of hacking.
+  "hacking>=5.0.0; python_version >= '3.8'",
+  "ruff; python_version >= '3.7'",
 ]
 lint-deep = [
-    "mypy",
-    "pylint",
-    # To prevent following error when running semgrep in Python 3.9:
-    # ModuleNotFoundError: No module named 'pkg_resources'
-    # - [BUG] Restore \`pkg\_resources\` · Issue #5174 · pypa/setuptools
-    #   https://github.com/pypa/setuptools/issues/5174
-    "setuptools<82.0.0; python_version == '3.9'",
-    # If we simply lock as "semgrep; python_version >= '3.9' or python_version>='3.6' and platform_system=='Linux'",
-    # the semgrep 1.121.0 is installed in Python 3.14 and cause following error:
-    #     File "/root/.local/share/uv/python/cpython-3.14.5-linux-aarch64-gnu/lib/python3.14/importlib/__init__.py", line 88, in import_module
-    #       return _bootstrap._gcd_import(name[level:], package, level)
-    #              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    #   TypeError: Metaclasses with custom tp_new are not supported.
-    "semgrep; python_version >= '3.9' and python_version < '3.10' or python_version>='3.6' and platform_system=='Linux'",
-    "semgrep>=1.122.0; python_version >= '3.10'",
-    # To prevent following error when running semgrep in Python 3.9:
-    # ModuleNotFoundError: No module named 'pkg_resources'
-    # - [BUG] Restore \`pkg\_resources\` · Issue #5174 · pypa/setuptools
-    #   https://github.com/pypa/setuptools/issues/5174
-    "setuptools<82.0.0; python_version == '3.9'",
+  "mypy",
+  "pylint",
+  # To prevent following error when running semgrep in Python 3.9:
+  # ModuleNotFoundError: No module named 'pkg_resources'
+  # - [BUG] Restore \`pkg\_resources\` · Issue #5174 · pypa/setuptools
+  #   https://github.com/pypa/setuptools/issues/5174
+  "setuptools<82.0.0; python_version == '3.9'",
+  # To prevent following error when uv lock:
+  #   × Failed to build `semgrep==0.86.3`
+  # ├─▶ The build backend returned an error
+  # ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+  #     [stderr]
+  #     Traceback (most recent call last):
+  #       File "<string>", line 14, in <module>
+  #         requires = get_requires_for_build({})
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
+  #         return self._get_build_requires(config_settings, requirements=[])
+  #                ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
+  #         self.run_setup()
+  #         ~~~~~~~~~~~~~~^^
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 520, in run_setup
+  #         super().run_setup(setup_script=setup_script)
+  #         ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
+  #         exec(code, locals())
+  #         ~~~~^^^^^^^^^^^^^^^^
+  #       File "<string>", line 94, in <module>
+  #       File "<string>", line 72, in find_executable
+  #     Exception: Could not find 'semgrep-core' executable, tried 'SEMGREP_CORE_BIN' and system 'semgrep-core'
+  # If we simply lock as "semgrep; python_version >= '3.9' or python_version>='3.6' and platform_system=='Linux'",
+  # the semgrep 1.121.0 is installed in Python 3.14 and cause following error:
+  #     File "/root/.local/share/uv/python/cpython-3.14.5-linux-aarch64-gnu/lib/python3.14/importlib/__init__.py", line 88, in import_module
+  #       return _bootstrap._gcd_import(name[level:], package, level)
+  #              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #   TypeError: Metaclasses with custom tp_new are not supported.
+  "semgrep>=0.87.0; python_version >= '3.9' and python_version < '3.10' or python_version>='3.6' and platform_system=='Linux'",
+  "semgrep>=1.122.0; python_version >= '3.10'",
+  # To prevent following error when running semgrep in Python 3.9:
+  # ModuleNotFoundError: No module named 'pkg_resources'
+  # - [BUG] Restore \`pkg\_resources\` · Issue #5174 · pypa/setuptools
+  #   https://github.com/pypa/setuptools/issues/5174
+  "setuptools<82.0.0; python_version == '3.9'",
 ]
 style = [
-    # To the docformatter load pyproject.toml settings:
-    # docformatter < 1.7.8 depends on untokenize==0.1.1, whose setup.py uses ast.Constant.s removed in Python 3.14:
-    # - Installation fails on Python 3.14 · Issue #327 · PyCQA/docformatter
-    #   https://github.com/PyCQA/docformatter/issues/327
-    # uv builds packages using the current interpreter to collect metadata for the lock file, so even a marker
-    # like `python_version < '3.14'` cannot prevent the build from running on Python 3.14 and failing.
-    # docformatter >= 1.7.8 dropped untokenize but requires Python >= 3.10, so Python 3.7-3.9 are excluded.
-    "docformatter[tomli]>=1.7.8; python_version >= '3.10' and python_version < '3.11'",
-    "docformatter>=1.7.8; python_version >= '3.11'",
-    "ruff; python_version >= '3.7'",
+  # To the docformatter load pyproject.toml settings:
+  # docformatter < 1.7.8 depends on untokenize==0.1.1, whose setup.py uses ast.Constant.s removed in Python 3.14:
+  # - Installation fails on Python 3.14 · Issue #327 · PyCQA/docformatter
+  #   https://github.com/PyCQA/docformatter/issues/327
+  # uv builds packages using the current interpreter to collect metadata for the lock file, so even a marker
+  # like `python_version < '3.14'` cannot prevent the build from running on Python 3.14 and failing.
+  # docformatter >= 1.7.8 dropped untokenize but requires Python >= 3.10, so Python 3.7-3.9 are excluded.
+  "docformatter[tomli]>=1.7.8; python_version >= '3.10' and python_version < '3.11'",
+  "docformatter>=1.7.8; python_version >= '3.11'",
+  "ruff; python_version >= '3.7'",
 ]
 style-legacy = [
-    "autoflake",
-    # If you want to use not Ruff but Black for formatting
-    "black; python_version >= '3.7'",
-    # If you want to use not Ruff but isort for formatting
-    "isort",
-    "pydocstyle; python_version >= '3.6'",
+  "autoflake",
+  # If you want to use not Ruff but Black for formatting
+  "black; python_version >= '3.7'",
+  # If you want to use not Ruff but isort for formatting
+  "isort",
+  "pydocstyle; python_version >= '3.6'",
 ]
 test = [
-    # The coverage==3.5.3 is difficult to analyze its dependencies by dependencies management tool,
-    # so we should avoid 3.5.3 or lower.
-    # - Command: "pipenv install --skip-lock" fails
-    #   since it tries to parse legacy package metadata and raise InstallError
-    #   · Issue #5595 · pypa/pipenv
-    #   https://github.com/pypa/pipenv/issues/5595
-    "coverage>=3.5.4",
-    "pytest",
+  # The coverage==3.5.3 is difficult to analyze its dependencies by dependencies management tool,
+  # so we should avoid 3.5.3 or lower.
+  # - Command: "pipenv install --skip-lock" fails
+  #   since it tries to parse legacy package metadata and raise InstallError
+  #   · Issue #5595 · pypa/pipenv
+  #   https://github.com/pypa/pipenv/issues/5595
+  "coverage>=3.5.4",
+  "pytest",
 ]
 xenon = [
-    # To use flake8 --radon-show-closures
-    "flake8-polyfill",
-    # Since the radon can't run when use pytest log format:
-    # - Radon can't run when use pytest log fornat: `$()d` · Issue #251 · rubik/radon
-    #   https://github.com/rubik/radon/issues/251
-    "radon<6.0.0",
-    "xenon",
+  # To use flake8 --radon-show-closures
+  "flake8-polyfill",
+  # Since the radon can't run when use pytest log format:
+  # - Radon can't run when use pytest log fornat: `$()d` · Issue #251 · rubik/radon
+  #   https://github.com/rubik/radon/issues/251
+  "radon<6.0.0",
+  "xenon",
 ]
 
 [project.urls]
@@ -213,13 +236,13 @@ replace = '__version__ = "{new_version}"'
 
 [tool.coverage.report]
 exclude_also = [
-    # Assume `if TYPE_CHECKING: ... else: ...` block is covered · Issue #831 · nedbat/coveragepy
-    #   https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185
-    "if TYPE_CHECKING:",
-    # Pylint will detect instead:
-    # - abstract-method / W0223 - Pylint 2.17.0-dev0 documentation
-    #   https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/abstract-method.html
-    "raise NotImplementedError",
+  # Assume `if TYPE_CHECKING: ... else: ...` block is covered · Issue #831 · nedbat/coveragepy
+  #   https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185
+  "if TYPE_CHECKING:",
+  # Pylint will detect instead:
+  # - abstract-method / W0223 - Pylint 2.17.0-dev0 documentation
+  #   https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/abstract-method.html
+  "raise NotImplementedError",
 ]
 
 [tool.docformatter]
@@ -277,23 +300,23 @@ ignore_missing_imports = true
 [tool.pydocstyle]
 convention = "google"
 add_ignore = [
-    # Reason: Docstring may be missed since docstring-min-length is set.
-    "D101",  # Missing docstring in public class
-    "D102",  # Missing docstring in public method
-    "D103",  # Missing docstring in public function
-    "D105",  # Missing docstring in magic method
-    "D106",  # Missing docstring in public nested class
-    "D107",  # Missing docstring in __init__
-    # Reason: First line may ends with function signature for expression.
-    "D402",  # First line should not be the function’s “signature”
-    # Reason: First line may ends with ":" for expression.
-    "D415",  # First line should end with a period, question mark, or exclamation point
+  # Reason: Docstring may be missed since docstring-min-length is set.
+  "D101",  # Missing docstring in public class
+  "D102",  # Missing docstring in public method
+  "D103",  # Missing docstring in public function
+  "D105",  # Missing docstring in magic method
+  "D106",  # Missing docstring in public nested class
+  "D107",  # Missing docstring in __init__
+  # Reason: First line may ends with function signature for expression.
+  "D402",  # First line should not be the function’s “signature”
+  # Reason: First line may ends with ":" for expression.
+  "D415",  # First line should end with a period, question mark, or exclamation point
 ]
 
 [tool.pylint]
 disable = [
-    # We check line length by flake8-bugbear B950.
-    "line-too-long",
+  # We check line length by flake8-bugbear B950.
+  "line-too-long",
 ]
 
 [tool.pylint.basic]
@@ -309,7 +332,7 @@ min-public-methods = "1"
 
 [tool.pytest.ini_options]
 markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 
 [tool.radon]
@@ -323,31 +346,31 @@ line-length = 119
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-    # lint.pydocstyle
-    # Reason: Docstring may be missed since docstring-min-length is set.
-    "D101",    # Missing docstring in public class
-    "D102",    # Missing docstring in public method
-    "D103",    # Missing docstring in public function
-    "D105",    # Missing docstring in magic method
-    "D106",    # Missing docstring in public nested class
-    "D107",    # Missing docstring in __init__
-    # Reason: First line may ends with function signature for expression.
-    "D402",    # First line should not be the function’s “signature”
-    # Reason: First line may ends with ":" for expression.
-    "D415",    # First line should end with a period, question mark, or exclamation point
-    # Reason: `Line too long` is checked by flake8-bugbear.
-    "E501",    # Line too long ({width} > {limit})
-    "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed, These warnings are disabled by default
+  # lint.pydocstyle
+  # Reason: Docstring may be missed since docstring-min-length is set.
+  "D101",    # Missing docstring in public class
+  "D102",    # Missing docstring in public method
+  "D103",    # Missing docstring in public function
+  "D105",    # Missing docstring in magic method
+  "D106",    # Missing docstring in public nested class
+  "D107",    # Missing docstring in __init__
+  # Reason: First line may ends with function signature for expression.
+  "D402",    # First line should not be the function’s “signature”
+  # Reason: First line may ends with ":" for expression.
+  "D415",    # First line should end with a period, question mark, or exclamation point
+  # Reason: `Line too long` is checked by flake8-bugbear.
+  "E501",    # Line too long ({width} > {limit})
+  "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed, These warnings are disabled by default
 ]
 fixable = [
-    "COM812",  # Trailing comma missing
-    "I",       # isort
-    "PT001",   # Use `@pytest.fixture()` over `@pytest.fixture`
-    "PT006",   # Wrong name(s) type in `@pytest.mark.parametrize`, expected `tuple`
-    "SIM108",  # Use ternary operator `extra_context = {} if extra_context is None else request.param` instead of `if`-`else`-block
-    "UP015",   # Unnecessary open mode parameters
-    "UP032",   # Use f-string instead of `format` call
-    "UP037",   # Remove quotes from type annotation
+  "COM812",  # Trailing comma missing
+  "I",       # isort
+  "PT001",   # Use `@pytest.fixture()` over `@pytest.fixture`
+  "PT006",   # Wrong name(s) type in `@pytest.mark.parametrize`, expected `tuple`
+  "SIM108",  # Use ternary operator `extra_context = {} if extra_context is None else request.param` instead of `if`-`else`-block
+  "UP015",   # Unnecessary open mode parameters
+  "UP032",   # Use f-string instead of `format` call
+  "UP037",   # Remove quotes from type annotation
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
This pull request updates the `semgrep` dependency constraint in `pyproject.toml` to address a build failure and improve compatibility with Python 3.9. Additionally, it adds detailed comments explaining the reasoning behind the change and the specific error encountered.

Dependency constraint update and documentation:

* Updated the `semgrep` dependency for Python 3.9 to require version `>=0.87.0`, preventing a build failure when running `uv lock` due to missing `semgrep-core` executable.
* Added a detailed comment block documenting the specific build error and the rationale for the new version constraint, improving maintainability and clarity for future contributors.