### PR TITLE
Update semgrep version constraints

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -1,5 +1,7 @@
 csvinput
 invokelint
+metaclass
+metaclasses
 returntocorp
 semgrep
 testlibraries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,14 @@ lint-deep = [
   #              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   #   TypeError: Metaclasses with custom tp_new are not supported.
   "semgrep>=0.87.0; python_version >= '3.9' and python_version < '3.10' or python_version>='3.6' and platform_system=='Linux'",
-  "semgrep>=1.122.0; python_version >= '3.10'",
+  "semgrep>=1.122.0; python_version >= '3.10' and python_version < '3.14'",
+  # The semgrep 1.122.0 - 1.136.0 also cause the TypeError above in Python 3.14 only:
+  # they pin opentelemetry-sdk ~= 1.25.0, whose opentelemetry-proto pins protobuf >=3.19,<5.0,
+  # and the C extension of protobuf 4.25.x is rejected by PyType_FromMetaclass in CPython 3.14.
+  # (PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python doesn't help
+  #  since protobuf 4.25.x reads it after probing the C extension.)
+  # The semgrep 1.137.0 bumps to opentelemetry-sdk ~= 1.37.0 which allows protobuf 5.x / 6.x supporting Python 3.14.
+  "semgrep>=1.137.0; python_version >= '3.14'",
   # To prevent following error when running semgrep in Python 3.9:
   # ModuleNotFoundError: No module named 'pkg_resources'
   # - [BUG] Restore \`pkg\_resources\` · Issue #5174 · pypa/setuptools


### PR DESCRIPTION
This pull request updates the `semgrep` dependency constraints to handle compatibility issues with Python 3.14 and adds new words to the project word list. The main focus is on ensuring that `semgrep` does not trigger errors related to metaclasses and the `protobuf` package in Python 3.14.

Dependency updates and compatibility fixes:

* Updated the `semgrep` dependency in `pyproject.toml` to restrict versions `>=1.122.0` to Python versions `<3.14`, and added a new constraint for `semgrep>=1.137.0` for Python 3.14 and above, to avoid issues with `protobuf` and metaclasses in Python 3.14.

Documentation and vocabulary:

* Added `metaclass` and `metaclasses` to `project-words.txt` to expand the project's recognized terminology.